### PR TITLE
fix subdir-objects problem on ubuntu 14.04.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT([libosmocore],
 	m4_esyscmd([./git-version-gen .tarball-version]),
 	[openbsc@lists.osmocom.org])
 
-AM_INIT_AUTOMAKE([foreign dist-bzip2 no-dist-gzip 1.6])
+AM_INIT_AUTOMAKE([subdir-objects foreign dist-bzip2 no-dist-gzip 1.6])
 AC_CONFIG_TESTDIR(tests)
 
 dnl kernel style compile messages


### PR DESCRIPTION
> src/gsm/Makefile.am:14: but option 'subdir-objects' is disabled
> automake: warning: possible forward-incompatibility.
> automake: At least a source file is in a subdirectory, but the 'subdir-objects'
